### PR TITLE
support for fix quality and fix mode

### DIFF
--- a/src/TinyGPSPlus.cpp
+++ b/src/TinyGPSPlus.cpp
@@ -260,6 +260,7 @@ bool TinyGPSPlus::endOfTermHandler()
       break;
     case COMBINE(GPS_SENTENCE_GPGGA, 6): // Fix data (GPGGA)
       sentenceHasFix = term[0] > '0';
+      location.newFixQuality = sentenceHasFix ? (FixQuality)(term[0] - '0') : Invalid;
       break;
     case COMBINE(GPS_SENTENCE_GPGGA, 7): // Satellites used (GPGGA)
       satellites.set(term);
@@ -269,6 +270,9 @@ bool TinyGPSPlus::endOfTermHandler()
       break;
     case COMBINE(GPS_SENTENCE_GPGGA, 9): // Altitude (GPGGA)
       altitude.set(term);
+      break;
+    case COMBINE(GPS_SENTENCE_GPRMC, 12):
+      location.newFixMode = (FixMode)term[0];
       break;
   }
 
@@ -337,6 +341,8 @@ void TinyGPSLocation::commit()
 {
    rawLatData = rawNewLatData;
    rawLngData = rawNewLngData;
+   fixQuality = newFixQuality;
+   fixMode = newFixMode;
    lastCommitTime = millis();
    valid = updated = true;
 }

--- a/src/TinyGPSPlus.h
+++ b/src/TinyGPSPlus.h
@@ -50,6 +50,9 @@ public:
    {}
 };
 
+enum FixQuality { Invalid = 0, GPS = 1, DGPS = 2, PPS = 3, RTK = 4, FloatRTK = 5, Estimated = 6, Manual = 7, Simulated = 8 };
+enum FixMode { N = 'N', A = 'A', D = 'D', E = 'E'};
+
 struct TinyGPSLocation
 {
    friend class TinyGPSPlus;
@@ -61,8 +64,10 @@ public:
    const RawDegrees &rawLng()     { updated = false; return rawLngData; }
    double lat();
    double lng();
+   FixQuality Quality() { updated = false; return fixQuality; }
+   FixMode Mode() { updated = false; return fixMode; }
 
-   TinyGPSLocation() : valid(false), updated(false)
+   TinyGPSLocation() : valid(false), updated(false), fixQuality(Invalid), newFixQuality(Invalid), fixMode(N), newFixMode(N)
    {}
 
 private:
@@ -72,6 +77,8 @@ private:
    void commit();
    void setLatitude(const char *term);
    void setLongitude(const char *term);
+   FixQuality fixQuality, newFixQuality;
+   FixMode fixMode, newFixMode;
 };
 
 struct TinyGPSDate


### PR DESCRIPTION
I think these belong inside the core API rather than only via use of custom; the lib as it stands is lacking in built in support for assessing fix quality.

add support for fix quality (GGA https://github.com/mikalhart/TinyGPSPlus/pull/6)
add support for fix mode (RMC https://github.com/mikalhart/TinyGPSPlus/issues/12) (NMEA 2.3+)

Base: https://github.com/mikalhart/TinyGPSPlus/pull/38